### PR TITLE
Minor pathextractor changes

### DIFF
--- a/pipeline/plugins/pathextractor/src/main/kotlin/nl/tudelft/hyperion/pipeline/pathextractor/Configuration.kt
+++ b/pipeline/plugins/pathextractor/src/main/kotlin/nl/tudelft/hyperion/pipeline/pathextractor/Configuration.kt
@@ -1,5 +1,6 @@
 package nl.tudelft.hyperion.pipeline.pathextractor
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import nl.tudelft.hyperion.pipeline.PipelinePluginConfiguration
 
 /**
@@ -10,8 +11,9 @@ import nl.tudelft.hyperion.pipeline.PipelinePluginConfiguration
  * @Param pipeline configuration for the abstract plugin
  */
 data class Configuration(
-        val field: String,
-        val relativePathFromSource: String,
-        val postfix: String,
-        val pipeline: PipelinePluginConfiguration
+    val field: String,
+    @JsonProperty("relative-source-path")
+    val relativePathFromSource: String,
+    val postfix: String,
+    val pipeline: PipelinePluginConfiguration
 )

--- a/pipeline/plugins/pathextractor/src/main/kotlin/nl/tudelft/hyperion/pipeline/pathextractor/ExtractPath.kt
+++ b/pipeline/plugins/pathextractor/src/main/kotlin/nl/tudelft/hyperion/pipeline/pathextractor/ExtractPath.kt
@@ -2,6 +2,9 @@ package nl.tudelft.hyperion.pipeline.pathextractor
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.databind.node.TextNode
+
+private val mapper = ObjectMapper()
 
 /**
  * Function that replaces the value of a package field with the actual java class path
@@ -9,24 +12,27 @@ import com.fasterxml.jackson.databind.node.ObjectNode
  * @param config The path renaming configuration
  * @return A JSON string with the new value
  */
+@Suppress("TooGenericExceptionCaught")
 fun extractPath(input: String, config: Configuration): String {
-    val mapper = ObjectMapper()
     val tree = mapper.readTree(input)
 
-    val parent = tree.findParent(config.field)
+    // Return value unmodified if not valid JSON or not an object
+    val parent = try {
+        tree.findParent(config.field) as ObjectNode
+    } catch (ex: Exception) {
+        return input
+    }
 
-    if (parent != null) {
-        val packageName = tree.findValue(config.field).toString().drop(1).dropLast(1).split(".")
+    val packageNode = tree.findValue(config.field)
 
-        var path = config.relativePathFromSource
-        for (subfolder in packageName) {
-            path += "/"
-            path += subfolder
+    if (packageNode is TextNode) {
+        // Drop Kt suffix for kotlin support.
+        val packageFields = packageNode.textValue().split(".").map {
+            if (it.endsWith("Kt")) it.dropLast(2) else it
         }
-        path += config.postfix
 
-        (parent as ObjectNode).remove(config.field)
-        parent.put(config.field, path)
+        val newValue = "${config.relativePathFromSource}/${packageFields.joinToString("/")}${config.postfix}"
+        parent.put(config.field, newValue)
     }
 
     return tree.toString()

--- a/pipeline/plugins/pathextractor/src/main/kotlin/nl/tudelft/hyperion/pipeline/pathextractor/Main.kt
+++ b/pipeline/plugins/pathextractor/src/main/kotlin/nl/tudelft/hyperion/pipeline/pathextractor/Main.kt
@@ -4,9 +4,8 @@ package nl.tudelft.hyperion.pipeline.pathextractor
 
 import nl.tudelft.hyperion.pipeline.runPipelinePlugin
 
-fun main(vararg args: String) {
-    runPipelinePlugin(
-            args.get(0),
-            ::ExtractPathPlugin
-    )
-}
+fun main(vararg args: String) = runPipelinePlugin(
+    args[0],
+    ::ExtractPathPlugin
+)
+

--- a/pipeline/plugins/pathextractor/src/test/kotlin/nl/tudelft/hyperion/pipeline/pathextractor/ConfigurationTests.kt
+++ b/pipeline/plugins/pathextractor/src/test/kotlin/nl/tudelft/hyperion/pipeline/pathextractor/ConfigurationTests.kt
@@ -13,7 +13,7 @@ class ConfigurationTests {
               plugin-id : "plugin1"
             
             field: "log4j_file"
-            relativePathFromSource: "src/main/java"
+            relative-source-path: "src/main/java"
             postfix: .java
         """.trimIndent()
 

--- a/pipeline/plugins/pathextractor/src/test/kotlin/nl/tudelft/hyperion/pipeline/pathextractor/ExtractTests.kt
+++ b/pipeline/plugins/pathextractor/src/test/kotlin/nl/tudelft/hyperion/pipeline/pathextractor/ExtractTests.kt
@@ -9,10 +9,10 @@ class ExtractTests {
     @Test
     fun testRenameLogLine() {
         val config = Configuration(
-                "log4j_file",
-                "src/main/java",
-                ".java",
-                PipelinePluginConfiguration("pathExtractor", "1.2.3.4:4567")
+            "log4j_file",
+            "src/main/java",
+            ".java",
+            PipelinePluginConfiguration("pathExtractor", "1.2.3.4:4567")
         )
 
         val input = """{ "log4j_file" :  "com.sap.enterprises.server.impl.TransportationService" }"""
@@ -29,10 +29,10 @@ class ExtractTests {
     @Test
     fun testParentNull() {
         val config = Configuration(
-                "nonExisting",
-                "src/main/java",
-                ".java",
-                PipelinePluginConfiguration("pathExtractor", "1.2.3.4:4567")
+            "nonExisting",
+            "src/main/java",
+            ".java",
+            PipelinePluginConfiguration("pathExtractor", "1.2.3.4:4567")
         )
 
         val input = """{ "log4j_file" :  "com.sap.enterprises.server.impl.TransportationService" }"""
@@ -40,6 +40,60 @@ class ExtractTests {
         val mapper = ObjectMapper()
 
         val treeExpected = mapper.readTree(input)
+        val treeActual = mapper.readTree(extractPath(input, config))
+
+        Assertions.assertEquals(treeExpected, treeActual)
+    }
+
+    @Test
+    fun testFieldNotString() {
+        val config = Configuration(
+            "log4j_file",
+            "src/main/java",
+            ".java",
+            PipelinePluginConfiguration("pathExtractor", "1.2.3.4:4567")
+        )
+
+        val input = """{"log4j_file":true}"""
+
+        val expected = input
+        val actual = extractPath(input, config)
+
+        Assertions.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testInputNotJSONObject() {
+        val config = Configuration(
+            "log4j_file",
+            "src/main/java",
+            ".java",
+            PipelinePluginConfiguration("pathExtractor", "1.2.3.4:4567")
+        )
+
+        val input = """true"""
+
+        val expected = input
+        val actual = extractPath(input, config)
+
+        Assertions.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testKotlinNamingSupport() {
+        val config = Configuration(
+            "log4j_file",
+            "src/main/kotlin",
+            ".kt",
+            PipelinePluginConfiguration("pathExtractor", "1.2.3.4:4567")
+        )
+
+        val input = """{ "log4j_file" :  "com.sap.enterprises.server.impl.TransportationServiceKt" }"""
+        val expected = """{"log4j_file":"src/main/kotlin/com/sap/enterprises/server/impl/TransportationService.kt"}"""
+
+        val mapper = ObjectMapper()
+
+        val treeExpected = mapper.readTree(expected)
         val treeActual = mapper.readTree(extractPath(input, config))
 
         Assertions.assertEquals(treeExpected, treeActual)


### PR DESCRIPTION
Some minor path extractor changes. In particular:

- `relativePathFromSource` is now `relative-source-path` to stay consistent with config naming style.
- A new `ObjectMapper` is now no longer constructed for every rename call.
- Inputs that are not a valid JSON object no longer crash the plugin, but instead return the value unmodified.
- Inputs where the target field is not a string no longer result in weird renames.
- Kotlin packages with a `Kt` suffix now automatically have that suffix removed.
- Some formatting changes.
- New tests for the previously mentioned features.