### PR TITLE
Adder no longer runs on every pull request

### DIFF
--- a/.github/workflows/pipeline_adder_check.yml
+++ b/.github/workflows/pipeline_adder_check.yml
@@ -5,9 +5,9 @@ name: Gradle check pipeline adder plugin
 
 on:
   pull_request:
-  push:
     paths:
       - 'pipeline/plugins/adder/**'
+  push:
     branches:
       - master
 


### PR DESCRIPTION
Looks like we forgot to change this when merging. It was running on unrelated pull requests (#63 for example).