### PR TITLE
Minor renamer changes

### DIFF
--- a/pipeline/plugins/renamer/src/main/kotlin/nl/tudelft/hyperion/pipeline/renamer/Configuration.kt
+++ b/pipeline/plugins/renamer/src/main/kotlin/nl/tudelft/hyperion/pipeline/renamer/Configuration.kt
@@ -2,7 +2,39 @@ package nl.tudelft.hyperion.pipeline.renamer
 
 import nl.tudelft.hyperion.pipeline.PipelinePluginConfiguration
 
-class Rename(val from: String, val to: String)
+/**
+ * Represents a single renaming entry, renaming [from] to [to].
+ */
+class Rename(val from: String, val to: String) {
+    /**
+     * Lazily caching list of [to] delimited by '.'.
+     */
+    val toParts by lazy {
+        to.split(".")
+    }
+
+    /**
+     * Lazily computed list of [toParts] with the exception
+     * of the last item.
+     */
+    val toPath by lazy {
+        toParts.subList(0, toParts.size - 1)
+    }
+
+    /**
+     * Lazily computed last item of [toPath].
+     */
+    val toFieldName by lazy {
+        toParts.last()
+    }
+
+    /**
+     * Lazily computed last item of [from].
+     */
+    val fromFieldName by lazy {
+        from.split(".").last()
+    }
+}
 
 /**
  * Configuration for renaming plugin

--- a/pipeline/plugins/renamer/src/main/kotlin/nl/tudelft/hyperion/pipeline/renamer/Rename.kt
+++ b/pipeline/plugins/renamer/src/main/kotlin/nl/tudelft/hyperion/pipeline/renamer/Rename.kt
@@ -7,13 +7,15 @@ import com.fasterxml.jackson.databind.node.ObjectNode
  * Helper function that will get or create an object child
  * of the current object node.
  */
-fun ObjectNode.findOrCreateChild(name: String): ObjectNode {
+fun ObjectNode.findOrCreateChild(name: String): ObjectNode? {
     if (this.get(name) != null) {
-        return this.get(name) as ObjectNode
+        return this.get(name) as? ObjectNode
     }
 
     return this.putObject(name)
 }
+
+private val mapper = ObjectMapper()
 
 /**
  * Renames fields of a JSON string according to a configuration
@@ -22,24 +24,26 @@ fun ObjectNode.findOrCreateChild(name: String): ObjectNode {
  * @param config the renaming configuration
  * @return A JSON string with renamed fields
  */
+@Suppress("TooGenericExceptionCaught")
 fun rename(json: String, config: Configuration): String {
-    val mapper = ObjectMapper()
-    val tree = mapper.readTree(json) as ObjectNode
+    val tree = try {
+        mapper.readTree(json) as ObjectNode
+    } catch (ex: Exception) {
+        return json
+    }
 
-    for (i in config.rename.indices) {
-        val parent = tree.findParent(config.rename[i].from)
-        val fieldName = config.rename[i].from.split(".").last()
+    for (rename in config.rename) {
+        val parent = tree.findParent(rename.from)
 
         if (parent != null) {
-            val value = tree.findPath(config.rename[i].from)
-            val parts = config.rename[i].to.split(".")
+            val value = tree.findPath(rename.from)
 
-            val target = parts.subList(0, parts.size - 1).fold(tree, { p, c ->
-                p.findOrCreateChild(c)
-            })
+            val target = rename.toPath.fold(tree as ObjectNode?, { p, c ->
+                p?.findOrCreateChild(c)
+            }) ?: continue
 
-            target.put(parts.last(), value)
-            parent.remove(fieldName)
+            target.put(rename.toFieldName, value)
+            parent.remove(rename.fromFieldName)
         }
     }
 

--- a/pipeline/plugins/renamer/src/test/kotlin/nl/tudelft/hyperion/pipeline/renamer/RenameTest.kt
+++ b/pipeline/plugins/renamer/src/test/kotlin/nl/tudelft/hyperion/pipeline/renamer/RenameTest.kt
@@ -69,4 +69,47 @@ class RenameTest {
 
         Assertions.assertEquals(treeBefore, treeAfter)
     }
+
+    @Test
+    fun testInputNotJSON() {
+        val config = Configuration(
+            listOf(
+                Rename(
+                    "log_line",
+                    "location.line"
+                )
+            ),
+            PipelinePluginConfiguration("renamer", "1.2.3.4:4567")
+        )
+
+        val input = "true"
+        val output = rename(input, config)
+
+        Assertions.assertEquals(input, output)
+    }
+
+    @Test
+    fun testRenameTargetExistsAndIsNotObject() {
+        val config = Configuration(
+            listOf(
+                Rename(
+                    "log_line",
+                    "location.line"
+                )
+            ),
+            PipelinePluginConfiguration("renamer", "1.2.3.4:4567")
+        )
+
+        val input = """{
+          "location": "not an object",
+          "log_line": 10
+        }""".trimIndent()
+
+        val mapper = ObjectMapper()
+
+        val treeBefore = mapper.readTree(input)
+        val treeAfter = mapper.readTree(rename(input, config))
+
+        Assertions.assertEquals(treeBefore, treeAfter)
+    }
 }


### PR DESCRIPTION
Some minor renamer changes. In particular:

- A new `ObjectMapper` is now no longer constructed for every rename call.
- Inputs that are not a valid JSON object no longer crash the plugin, but instead return the value unmodified.
- Rename targets where the target is nested and a step in the path is not an object no longer crash the plugin, but instead return the value unmodified.
- New tests for the previously mentioned features.