### PR TITLE
Verify timestamp values in aggregator

### DIFF
--- a/aggregator/README.md
+++ b/aggregator/README.md
@@ -63,6 +63,15 @@ granularity: 60 # a minute
 # the amount of data stored in the database.
 aggregation-ttl: 604800 # 7 days
 
+# Whether or not incoming timestamps should be validated to verify whether
+# they lie within the current intermediate aggregation as determined by the
+# granularity. If this is set to `true` (the default value), messages will
+# not be aggregated if they are too old (their granularity window has already
+# passed) or if the timestamp is missing entirely. If this is set to `false`,
+# all received messages will be assumed to have occurred in the current
+# granularity window, regardless of their actual timestamp value.
+verify-timestamp: false
+
 # Various settings needed for the aggregator to interact with the pipeline,
 # such as it's unique ID and the hostname and port of the Hyperion plugin manager.
 # 
@@ -98,5 +107,8 @@ The aggregator expects JSON input messages that adhere to the following format. 
     "timestamp": "<an ISO 8601-parsable timestamp that represents the time at which this log occurred>"
 }
 ```
+
+The `timestamp` value is required if `verify-timestamp` is set to true. If timestamp verification is turned off, the
+ timestamp value can be ignored.
 
 If any of these fields are invalid or otherwise fail to parse, a warning is logged and the message is ignored. Please note that such warnings are logged on every single invocation, so they may get out of hand quickly depending on how many erroneous requests arrive.

--- a/aggregator/src/main/kotlin/nl/tudelft/hyperion/aggregator/Configuration.kt
+++ b/aggregator/src/main/kotlin/nl/tudelft/hyperion/aggregator/Configuration.kt
@@ -33,6 +33,12 @@ data class Configuration(
     @JsonProperty("aggregation-ttl")
     val aggregationTtl: Int,
     /**
+     * Whether or not timestamp fields should be validated for being
+     * in the correct granularity when a message is received.
+     */
+    @JsonProperty("verify-timestamp")
+    val verifyTimestamp: Boolean = true,
+    /**
      * The connection information for the ZMQ plugin manager.
      */
     val pipeline: ZMQConfiguration = ZMQConfiguration("localhost:30101", "Aggregator")

--- a/aggregator/src/main/kotlin/nl/tudelft/hyperion/aggregator/Main.kt
+++ b/aggregator/src/main/kotlin/nl/tudelft/hyperion/aggregator/Main.kt
@@ -55,7 +55,7 @@ fun coMain(configPath: String) = GlobalScope.launch {
             " granularity of ${config.granularity} seconds. ^C to exit."
     }
 
-    val intake = ZMQIntake(config.pipeline, aggregationManager)
+    val intake = ZMQIntake(config, aggregationManager)
     intake.setup()
 
     joinAll(

--- a/aggregator/src/main/kotlin/nl/tudelft/hyperion/aggregator/api/LogEntry.kt
+++ b/aggregator/src/main/kotlin/nl/tudelft/hyperion/aggregator/api/LogEntry.kt
@@ -49,9 +49,11 @@ data class LogEntry(
     val location: LogLocation,
 
     /**
-     * The time at which this log statement happened.
+     * The time at which this log statement happened. Note that this is nullable.
+     * When null, the [Configuration.verifyTimestamp] property determines whether
+     * or not this message is rejected.
      */
-    val timestamp: DateTime
+    val timestamp: DateTime? = null
 ) {
     companion object {
         private val mapper = ObjectMapper(JsonFactory())

--- a/aggregator/src/test/kotlin/nl/tudelft/hyperion/aggregator/ConfigurationTest.kt
+++ b/aggregator/src/test/kotlin/nl/tudelft/hyperion/aggregator/ConfigurationTest.kt
@@ -44,6 +44,7 @@ class ConfigurationTest : TestWithoutLogging() {
             port: 8081
             granularity: 10 # 10 seconds
             aggregation-ttl: 604800 # 7 days
+            verify-timestamp: false
         """.trimIndent()
 
         val config = Configuration.parse(content)
@@ -51,7 +52,8 @@ class ConfigurationTest : TestWithoutLogging() {
             "postgresql://localhost/postgres?user=postgres&password=mysecretpassword",
             8081,
             10,
-            604800
+            604800,
+            false
         )
         assertEquals(config, expected)
     }


### PR DESCRIPTION
This is the solution to #58 that we discussed earlier. Timestamps will be verified to be non-null and lying within the granularity, unless it is explicitly turned off in the config. README updated and new tests added, when appropriate.