### PR TITLE
Convert path of config to absolute path

### DIFF
--- a/pipeline/plugins/adder/src/main/kotlin/nl/tudelft/hyperion/pipeline/plugins/adder/AdderPlugin.kt
+++ b/pipeline/plugins/adder/src/main/kotlin/nl/tudelft/hyperion/pipeline/plugins/adder/AdderPlugin.kt
@@ -79,7 +79,7 @@ class AdderPlugin(var config: AdderConfiguration) : TransformingPipelinePlugin(c
         // setup directory changed watcher for the configuration file
         val watchService = FileSystems.getDefault().newWatchService()
         val configName = Path.of(path).fileName
-        val configDir = Path.of(path).parent
+        val configDir = Path.of(path).toAbsolutePath().parent
         configDir.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY)
 
         // poll for file changes


### PR DESCRIPTION
Fixes NPE thrown when packaged in a jar and given a relative path to the `config.yml`