### PR TITLE
feat(pipeline): Allow configurable buffer tracking, enable it for aggregator

### DIFF
--- a/aggregator/src/main/kotlin/nl/tudelft/hyperion/aggregator/intake/ZMQIntake.kt
+++ b/aggregator/src/main/kotlin/nl/tudelft/hyperion/aggregator/intake/ZMQIntake.kt
@@ -22,6 +22,10 @@ class ZMQIntake(
 ) : AbstractPipelinePlugin(configuration) {
     override val logger = mu.KotlinLogging.logger {}
 
+    // Ensure that commons takes care of buffering issues.
+    override val shouldLimitBuffer: Boolean
+        get() = true
+
     // Ensure that we're a receiver.
     override fun run(context: CoroutineContext): Job {
         if (!canReceive) {


### PR DESCRIPTION
Previously the aggregator would infinitely increase memory if it was getting more messages than it could handle.