### PR TITLE
Make Related Lines table non-editable

### DIFF
--- a/plugin/src/main/kotlin/nl/tudelft/hyperion/plugin/visualization/components/CodeList.kt
+++ b/plugin/src/main/kotlin/nl/tudelft/hyperion/plugin/visualization/components/CodeList.kt
@@ -77,10 +77,15 @@ class CodeList {
      */
     fun createUIComponents() {
         metricsTable = JBTable(
-            DefaultTableModel(
+            // Create anonymous inner class to override isCellEditable method.
+            object : DefaultTableModel(
                 arrayOf("Path", "File", "Line Number", "Severity", "Trigger Count"),
                 0
-            )
+            ) {
+                override fun isCellEditable(row: Int, column: Int): Boolean {
+                    return false
+                }
+            }
         )
     }
 

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -21,7 +21,7 @@
     <change-notes>
         <![CDATA[
         <ul>
-            <li>Change the color pallette for the Visualization Histograms.</li>
+            <li>Change the color palette for the Visualization Histograms.</li>
             <li>Changed Related Lines table to a non-editable table.</li>
         </ul>
         ]]>

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -17,8 +17,16 @@
           for more information on how to get started.
         ]]>
     </description>
-    <version>1.0.5</version>
-    <change-notes>Made it more clear that the API address should include http:// to work correctly</change-notes>
+    <version>1.1.1</version>
+    <change-notes>
+        <![CDATA[
+        <ul>
+            <li>Change the color pallette for the Visualization Histograms.</li>
+            <li>Changed Related Lines table to a non-editable table.</li>
+        </ul>
+        ]]>
+    </change-notes>
+
     <vendor url="https://se.ewi.tudelft.nl/" email="m.f.aniche@tudelft.nl">serg-delft</vendor>
     <depends>com.intellij.modules.platform</depends>
     <depends>Git4Idea</depends>


### PR DESCRIPTION
Adds one final change to the plugin. Once this is merged version 1.1.1 will be published on the Marketplace that includes the changes from #142 
Closes #143 